### PR TITLE
Fix: Resolve 'Tag is not defined' error in production

### DIFF
--- a/src/components/Events/EventCard.tsx
+++ b/src/components/Events/EventCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import RegistrationModal from './RegistrationModal';
 import CountdownTimer from '../ui/CountdownTimer';
 import { Event } from '../../types/Events/event';
-import { Calendar, Clock, MapPin, Users, Tag } from 'lucide-react';
+import { Calendar, Clock, MapPin, Users, Tag as TagIcon } from 'lucide-react';
 
 interface EventCardProps {
   event: Event;
@@ -67,7 +67,7 @@ const EventCard: React.FC<EventCardProps> = ({ event }) => {
                 key={index}
                 className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
               >
-                <Tag className="w-3 h-3 mr-1" />
+                <TagIcon className="w-3 h-3 mr-1" />
                 {tag}
               </span>
             ))}

--- a/src/components/Events/EventDetail.tsx
+++ b/src/components/Events/EventDetail.tsx
@@ -25,7 +25,6 @@ import {
   Phone, 
   User, 
   ArrowLeft,
-  Tag,
   AlertCircle,
   CheckCircle,
   XCircle,


### PR DESCRIPTION
- Remove unused Tag import from EventDetail.tsx
- Alias Tag import as TagIcon in EventCard.tsx to avoid naming conflicts
- Fix Information section alignment with proper table-like layout
- Add ImageModal functionality for Event Gallery images
- Swap Speakers and Event Gallery sections order (Speakers first)

Fixes production deployment issue where Tag component was undefined in Netlify build.